### PR TITLE
meta: add start of general/coverage testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false
+
+[*.js]
+indent_size = 4
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false
+
+[*.js]
+indent_size = 8
+indent_style = tab
+
+
+[*.json]
+indent_size = 8
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,10 @@ insert_final_newline = true
 trim_trailing_whitespace = false
 
 [*.js]
-indent_size = 4
+indent_size = 8
+indent_style = tab
+
+
+[*.json]
+indent_size = 8
 indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 npo.js
+coverage
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+   - "0.8"
+   - "0.10"

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "native-promise-only",
-  "version": "0.4.1-a",
-  "description": "Native Promise Only: A polyfill for native ES6 Promises **only**, nothing else.",
-  "main": "./npo.js",
-  "scripts": {
-    "test": "promises-aplus-tests test_adapter.js",
-    "cover": "istanbul cover --print=both ./node_modules/mocha/bin/_mocha",
-    "build": "./build.js"
-  },
-  "devDependencies": {
-    "istanbul": "^0.2.10",
-    "mocha": "^1.20.1",
-    "promises-aplus-tests": "*",
-    "uglify-js": "~2.4.8"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/getify/native-promise-only.git"
-  },
-  "keywords": [
-    "ES6",
-    "Promise",
-    "async"
-  ],
-  "bugs": {
-    "url": "https://github.com/getify/native-promise-only/issues",
-    "email": "getify@gmail.com"
-  },
-  "homepage": "http://github.com/getify/native-promise-only",
-  "author": "Kyle Simpson <getify@gmail.com>",
-  "license": "MIT"
+	"name": "native-promise-only",
+	"version": "0.4.1-a",
+	"description": "Native Promise Only: A polyfill for native ES6 Promises **only**, nothing else.",
+	"main": "./npo.js",
+	"scripts": {
+		"test": "promises-aplus-tests test_adapter.js",
+		"cover": "istanbul cover --print=both ./node_modules/mocha/bin/_mocha",
+		"build": "./build.js"
+	},
+	"devDependencies": {
+		"istanbul": "^0.2.10",
+		"mocha": "^1.20.1",
+		"promises-aplus-tests": "*",
+		"uglify-js": "~2.4.8"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/getify/native-promise-only.git"
+	},
+	"keywords": [
+		"ES6",
+		"Promise",
+		"async"
+	],
+	"bugs": {
+		"url": "https://github.com/getify/native-promise-only/issues",
+		"email": "getify@gmail.com"
+	},
+	"homepage": "http://github.com/getify/native-promise-only",
+	"author": "Kyle Simpson <getify@gmail.com>",
+	"license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
 	"name": "native-promise-only",
-	"version": "0.7.6-a",
+	"version": "0.7.7-a",
 	"description": "Native Promise Only: A polyfill for native ES6 Promises **only**, nothing else.",
 	"main": "./npo.js",
 	"scripts": {
 		"test": "promises-aplus-tests test_adapter.js",
+		"cover": "istanbul cover --print=both ./node_modules/mocha/bin/_mocha",
 		"build": "./build.js"
 	},
 	"devDependencies": {
+		"istanbul": "^0.2.10",
+		"mocha": "^1.20.1",
 		"promises-aplus-tests": "*",
 		"uglify-js": "~2.4.8"
 	},

--- a/package.json
+++ b/package.json
@@ -1,30 +1,33 @@
 {
-	"name": "native-promise-only",
-	"version": "0.4.1-a",
-	"description": "Native Promise Only: A polyfill for native ES6 Promises **only**, nothing else.",
-	"main": "./npo.js",
-	"scripts": {
-		"test": "promises-aplus-tests test_adapter.js",
-		"build": "./build.js"
-	},
-	"devDependencies": {
-		"promises-aplus-tests": "*",
-		"uglify-js": "~2.4.8"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/getify/native-promise-only.git"
-	},
-	"keywords": [
-		"ES6",
-		"Promise",
-		"async"
-	],
-	"bugs": {
-		"url": "https://github.com/getify/native-promise-only/issues",
-		"email": "getify@gmail.com"
-	},
-	"homepage": "http://github.com/getify/native-promise-only",
-	"author": "Kyle Simpson <getify@gmail.com>",
-	"license": "MIT"
+  "name": "native-promise-only",
+  "version": "0.4.1-a",
+  "description": "Native Promise Only: A polyfill for native ES6 Promises **only**, nothing else.",
+  "main": "./npo.js",
+  "scripts": {
+    "test": "promises-aplus-tests test_adapter.js",
+    "cover": "istanbul cover --print=both ./node_modules/mocha/bin/_mocha",
+    "build": "./build.js"
+  },
+  "devDependencies": {
+    "istanbul": "^0.2.10",
+    "mocha": "^1.20.1",
+    "promises-aplus-tests": "*",
+    "uglify-js": "~2.4.8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/getify/native-promise-only.git"
+  },
+  "keywords": [
+    "ES6",
+    "Promise",
+    "async"
+  ],
+  "bugs": {
+    "url": "https://github.com/getify/native-promise-only/issues",
+    "email": "getify@gmail.com"
+  },
+  "homepage": "http://github.com/getify/native-promise-only",
+  "author": "Kyle Simpson <getify@gmail.com>",
+  "license": "MIT"
 }

--- a/test/dummy.js
+++ b/test/dummy.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var assert = require("assert");
+var npo = require("../lib/npo.src.js");
+
+describe("static helper unit tests", function () {
+	assert.ok(true);
+});


### PR DESCRIPTION
.gitattributes - easier for windows user to contribute
.editorconfig - easier for emacs user to contribute
.gitignore - ignore emacs backup files, coverage directory

package.json - add mocha, istanbul, coverage script
test/dummy.js - add dummy test to report coverage

meta: correct .editorconfig, add json
meta: restore formatting
add .travis.yml

meta: bump minor version and restore keyword
