### PR TITLE
Fix issue #38: broken defineProperty on Android 4 with .prototype

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,7 +4,8 @@ var fs = require("fs"),
 	path = require("path"),
 	exec = require("child_process").exec,
 	ugly = require("uglify-js"),
-
+        files = ["header.js", "guards.js", "npo.src.js"],
+        
 	result
 ;
 
@@ -12,12 +13,12 @@ console.log("*** Building ***");
 console.log("Minifying to npo.js.");
 
 try {
-	result = ugly.minify(path.join(__dirname,"lib","npo.src.js"),{
+	result = ugly.minify(files.map(function (f) {
+			return path.join(__dirname,"lib",f);
+		}),{
 		mangle: true,
 		compress: true,
-		output: {
-			comments: /^!/
-		}
+		output: { comments: /^!/ }
 	});
 
 	fs.writeFileSync(

--- a/lib/guards.js
+++ b/lib/guards.js
@@ -1,0 +1,14 @@
+(function(){
+    var x = {}, y = function(){};
+
+    try {
+	// dammit, IE8
+	Object.defineProperty(x,"x",x);
+	// dammit, Android
+	Object.defineProperty(y,"prototype",{ value: x });
+	if (y.prototype !== x) throw x;
+    }
+    catch(e) {
+	(Object.defineProperty || x).NPO_AVOID = true;
+    }
+}());

--- a/lib/header.js
+++ b/lib/header.js
@@ -1,0 +1,4 @@
+/*! Native Promise Only
+    v0.7.7-a (c) Kyle Simpson
+    MIT License: http://getify.mit-license.org
+*/

--- a/lib/npo.src.js
+++ b/lib/npo.src.js
@@ -1,8 +1,3 @@
-/*! Native Promise Only
-    v0.7.6-a (c) Kyle Simpson
-    MIT License: http://getify.mit-license.org
-*/
-
 (function UMD(name,context,definition){
 	// special form of UMD for polyfilling across evironments
 	context[name] = context[name] || definition();
@@ -19,23 +14,17 @@
 			setTimeout
 	;
 
-	// damnit, IE8.
-	try {
-		Object.defineProperty({},"x",{});
-		builtInProp = function builtInProp(obj,name,val,config) {
+        builtInProp = Object.defineProperty && (!Object.defineProperty.NPO_AVOID) ?
+                    function builtInProp(obj,name,val,config) {
 			return Object.defineProperty(obj,name,{
 				value: val,
 				writable: true,
 				configurable: config !== false
 			});
-		};
-	}
-	catch (err) {
-		builtInProp = function builtInProp(obj,name,val) {
+		    } : function builtInProp_compat(obj,name,val) {
 			obj[name] = val;
 			return obj;
-		};
-	}
+                    };
 
 	// Note: using a queue instead of array for efficiency
 	scheduling_queue = (function Queue() {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
 	"name": "native-promise-only",
-	"version": "0.7.6-a",
+	"version": "0.7.7-a",
 	"description": "Native Promise Only: A polyfill for native ES6 Promises **only**, nothing else.",
 	"main": "./npo.js",
 	"scripts": {
-		"test": "promises-aplus-tests test_adapter.js",
+		"test": "mocha && promises-aplus-tests test_adapter.js",
 		"build": "./build.js"
 	},
 	"devDependencies": {
-		"promises-aplus-tests": "*",
-		"uglify-js": "~2.4.8"
+		"promises-aplus-tests": "~2.1.0",
+		"uglify-js": "~2.4.8",
+		"mocha": "~2.0.1"
 	},
 	"repository": {
 		"type": "git",

--- a/test/regression.js
+++ b/test/regression.js
@@ -1,0 +1,42 @@
+// regression for issue #38
+var assert = require('assert'),
+    path = require('path');
+
+describe("when Object.defineProperty may be broken", function () {
+    var realDefineProperty = Object.defineProperty;
+    var guards = path.join(__dirname, "../lib/guards.js");
+
+    beforeEach(function () {
+        Object.defineProperty = undefined;
+    });
+    afterEach(function () {
+        Object.defineProperty = realDefineProperty;
+        delete require.cache[guards];
+    });
+
+    it("runs a test suite", function () {
+        assert.equal(1,1);   
+    });
+
+    it("works under node/v8 with no changes", function () {
+        Object.defineProperty = realDefineProperty;
+        require(guards);
+        assert.equal(Object.defineProperty.NPO_AVOID, undefined);
+    });
+
+    it("identifies a fully broken object.defineProperty", function () {
+        Object.defineProperty = function () {};
+        require(guards);
+        assert.equal(Object.defineProperty.NPO_AVOID, true);
+    });
+
+    it("identifies a partially broken object.defineProperty", function () {
+        Object.defineProperty = function (obj, name, prop) {
+            if ((obj instanceof Function) && name === "prototype") return;
+
+            return realDefineProperty(obj, name, prop);
+        };
+        require(guards);
+        assert.equal(Object.defineProperty.NPO_AVOID, true);
+    });
+});


### PR DESCRIPTION
candidate for issue #38
add explanatory comment
make x be a function to trigger android defineProperty() bug

build: source is now several files
move header, guards to separate file
ensure header comment comes first
factor out Object.defineProperty guards
bump version
add mocha as devDependency
bump version
add tests and run them