### PR TITLE
Add CDNJS version badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Native Promise Only (NPO)
 
+[![CDNJS](https://img.shields.io/cdnjs/v/native-promise-only.svg)](https://cdnjs.com/libraries/native-promise-only/)
+
 A polyfill for native ES6 Promises as close as possible (no extensions) to the strict spec definitions.
 
 ## Intent


### PR DESCRIPTION
This will add the badge to show its version on CDNJS and also link to its page on CDNJS!